### PR TITLE
ENH: add default parameters to hist_math_worker + support color_space=None

### DIFF
--- a/rio_hist/scripts/cli.py
+++ b/rio_hist/scripts/cli.py
@@ -20,7 +20,7 @@ def _validate_proportion(ctx, param, value):
 @click.option(
     "--color-space",
     "-c",
-    default="RGB",
+    default=None,
     type=click.Choice(["RGB", "LCH", "LAB", "Lab", "LUV", "XYZ"]),
     help="Colorspace",
 )

--- a/rio_hist/utils.py
+++ b/rio_hist/utils.py
@@ -23,9 +23,14 @@ def reshape_as_raster(arr):
 
 def cs_forward(arr, cs="rgb"):
     """RGB (any dtype) to whatevs."""
+    # First normalize the array to [0, 1] range.
     arrnorm = arr.astype("float64") / np.iinfo(arr.dtype).max
-    cs = cs.lower()
-    if cs == "rgb":
+
+    # Convert color space (in needed).
+    if cs is not None:
+        cs = cs.lower()
+
+    if cs is None or cs == "rgb":
         return arrnorm
     elif cs == "lch":
         return convert_arr(arrnorm, src=ColorSpace.rgb, dst=ColorSpace.lch)
@@ -39,8 +44,10 @@ def cs_forward(arr, cs="rgb"):
 
 def cs_backward(arr, cs="rgb"):
     """Whatevs to RGB 8-bit."""
-    cs = cs.lower()
-    if cs == "rgb":
+    if cs is not None:
+        cs = cs.lower()
+
+    if cs is None or cs == "rgb":
         return (arr * 255).astype("uint8")
     elif cs == "lch":
         rgb = convert_arr(arr, src=ColorSpace.lch, dst=ColorSpace.rgb)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,25 +1,32 @@
+import numpy as np
+import pytest
 import rasterio
 
 from rio_hist import match
 
 
-def test_hist_match_worker(tmp_path):
+@pytest.mark.parametrize(
+    "src_path, expected_bands",
+    [
+        ("tests/data/source1.tif", 3),  # RGB
+        ("tests/data/source2.tif", 4),  # RGBA
+    ],
+)
+def test_hist_match_worker(tmp_path, src_path, expected_bands):
     """Test the histogram matching worker function."""
     dst_path = tmp_path / "output.tif"
     match.hist_match_worker(
-        src_path="tests/data/source1.tif",
+        src_path=src_path,
         ref_path="tests/data/reference1.tif",
         dst_path=dst_path,
         match_proportion=0.5,
-        creation_options={},
-        bands="1,2,3",
+        bands=[1, 2, 3],
         color_space="RGB",
-        plot=False,
     )
 
     assert dst_path.exists()
     with rasterio.open(dst_path) as out:
-        assert out.count == 3  # RGB
+        assert out.count == expected_bands
 
 
 def test_hist_match_worker_bands(tmp_path):
@@ -30,12 +37,37 @@ def test_hist_match_worker_bands(tmp_path):
         ref_path="tests/data/reference1.tif",
         dst_path=dst_path,
         match_proportion=0.5,
-        creation_options={},
         bands="1,2",
-        color_space="RGB",
-        plot=False,
     )
 
     assert dst_path.exists()
     with rasterio.open(dst_path) as out:
         assert out.count == 2  # RG
+
+
+@pytest.mark.parametrize("color_space", ["RGB", "LCH", "LAB", "LUV", "XYZ"])
+def test_hist_match_worker_colorspace(tmp_path, color_space):
+    """Test the histogram matching worker function."""
+    dst_path = tmp_path / "output.tif"
+    match.hist_match_worker(
+        src_path="tests/data/source1.tif",
+        ref_path="tests/data/reference1.tif",
+        dst_path=dst_path,
+        match_proportion=0.5,
+        bands="1,2,3",
+        color_space=color_space,
+    )
+
+    assert dst_path.exists()
+    with (
+        rasterio.open(dst_path) as dst_file,
+        rasterio.open("tests/data/source1.tif") as src_file,
+        rasterio.open("tests/data/reference1.tif") as ref_file,
+    ):
+        assert dst_file.count == 3
+
+        dst = dst_file.read(2)
+        src = src_file.read(2)
+        ref = ((ref_file.read(2) / 65365) * 256).astype("uint8")
+        assert np.median(src) > np.median(dst)  # darker than the source
+        assert np.median(ref) < np.median(dst)  # but not quite as dark as the reference


### PR DESCRIPTION
- Make `hist_math_worker` a proper public function by adding default parameters + document them
- Add support for `color_space=None` if no color space transformation is wanted, which is more logical if there are < 3 bands